### PR TITLE
Fixing issue where pawns not on a map, but have a hediff added, might…

### DIFF
--- a/TerrainMovementKit/Pawn.cs
+++ b/TerrainMovementKit/Pawn.cs
@@ -260,7 +260,7 @@ namespace TerrainMovement
                 bestStats = (StatDefOf.MoveSpeed, StatDefOf.MoveSpeed);
             }
             float curSpeed = -1;
-            var curJob = pawn.jobs.curJob;
+            var curJob = pawn.jobs?.curJob;
             LocomotionUrgency urgency = (curJob == null) ? LocomotionUrgency.None : curJob.locomotionUrgency;
             foreach (var terrainStats in terrain.TerrainMovementStatDefs(pawn.kindDef.AllowsBasicMovement(), urgency))
             {


### PR DESCRIPTION
… trip a null pointer exception.

Issue is initially caused by a delegate attached to hediff set on pawns, which would notify on change and force a recalculation of movement rates. As a pawn that has never been on the map would not have an active jobs list, this would cause a nullref exception.